### PR TITLE
Fix filter condition

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -10,10 +10,9 @@ const TaskManager = () => {
   const [filter, setFilter] = useState("all");
   const [newTask, setNewTask] = useState<string>();
 
-  // Intentional bug: The filter conditions are reversed.
   const filteredTasks = tasks.filter((task) => {
-    if (filter === "completed") return task.completed === false;
-    if (filter === "pending") return task.completed === true;
+    if (filter === "completed") return task.completed === true;
+    if (filter === "pending") return task.completed === false;
     return true;
   });
 


### PR DESCRIPTION
### Summary

When filtering tasks, completed tasks were incorrectly displaying as pending and vice versa.
In order to fix it, the conditions inside the task array filter method where inverted.

### Test Cases

- Completed tasks:
1. Go to the tab `Completed`.
2. The task `Clean the house` should be displayed.

- Pending tasks:
1. Go to the tab `Pending`.
2. The task `Buy groceries` should be displayed.

### Screenshots

- Before the fix (`Clean the house` is `completed` and `Buy groceries` is `pending`):
<img width="812" alt="image" src="https://github.com/user-attachments/assets/bcf7d509-622e-4233-be95-154b9cda929b" />
<img width="816" alt="image" src="https://github.com/user-attachments/assets/100f23d2-95c3-4cd5-9850-cc7a1d577746" />

- After the fix (Clean the house is completed and `Buy groceries` is not completed):
<img width="811" alt="image" src="https://github.com/user-attachments/assets/69446dee-ddc7-477f-9861-95b60bd65c7c" />
<img width="811" alt="image" src="https://github.com/user-attachments/assets/7912af24-13b5-4fa1-b69f-e347c740f207" />
