### PR TITLE
Fix deletion button not updating the UI immediately

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -28,13 +28,8 @@ const TaskManager = () => {
     setNewTask("");
   };
 
-  // Intentional bug: Directly mutating the tasks array when deleting.
   const handleDeleteTask = (id: number) => {
-    const index = tasks.findIndex((task) => task.id === id);
-    if (index !== -1) {
-      tasks.splice(index, 1);
-      setTasks(tasks);
-    }
+    setTasks(tasks.filter((task) => task.id !== id));
   };
 
   const toggleTaskCompletion = (id: number) => {


### PR DESCRIPTION
### Summary

When deleting a task, the UI was not updating correctly since the array in the state was being mutated.
In order to fix it, I used the `filter` method to create a new array without the selected task.

### Test Cases

1. Click the `Delete` button on any task.
2. The task should be deleted from the UI.

### Screen Recordings

- Before the fix:

[video.mov](https://github.com/user-attachments/assets/6087dd1e-cf0f-4c1d-a973-a78b310aeebd)

- After the fix:

[video.mov](https://github.com/user-attachments/assets/78b960cc-d75f-4651-a18b-1d415f6ab8eb)

