### PR TITLE
Store tasks in localStorage

### DIFF
--- a/src/store/taskStore.ts
+++ b/src/store/taskStore.ts
@@ -12,26 +12,38 @@ type TaskStore = {
 };
 
 const useTaskStore = create<TaskStore>()((set) => ({
-  tasks: [
+  tasks: JSON.parse(localStorage.getItem("tasks") || "null") || [
     { id: 1, title: "Buy groceries", completed: false },
     { id: 2, title: "Clean the house", completed: true },
   ],
   currentFilter: "all",
   addTask: (title: string) =>
-    set((state) => ({
-      tasks: [
+    set((state) => {
+      const updatedTasks = [
         ...state.tasks,
         { id: state.tasks.length + 1, title, completed: false },
-      ],
-    })),
+      ];
+      localStorage.setItem("tasks", JSON.stringify(updatedTasks));
+      return {
+        tasks: updatedTasks,
+      };
+    }),
   deleteTask: (id: number) =>
-    set((state) => ({ tasks: state.tasks.filter((task) => task.id !== id) })),
+    set((state) => {
+      const updatedTasks = state.tasks.filter((task) => task.id !== id);
+      localStorage.setItem("tasks", JSON.stringify(updatedTasks));
+      return { tasks: updatedTasks };
+    }),
   toggleTaskCompletion: (id: number) =>
-    set((state) => ({
-      tasks: state.tasks.map((task) =>
+    set((state) => {
+      const updatedTasks = state.tasks.map((task) =>
         task.id === id ? { ...task, completed: !task.completed } : task
-      ),
-    })),
+      );
+      localStorage.setItem("tasks", JSON.stringify(updatedTasks));
+      return {
+        tasks: updatedTasks,
+      };
+    }),
   setFilter: (filter: Filter) => set(() => ({ currentFilter: filter })),
 }));
 


### PR DESCRIPTION
### Summary

- Ensure every change in the tasks array is persisted in `localStorage`.
- When initializing the store, load the tasks from `localStorage`.

### Test Cases

- Create a task, reload the page, and verify that the new task is still there.
- Delete a task, reload the page, and verify that the task is still deleted.
- Toggle a task status, reload the page, and verify that the task status is the same.

### Screen Captures

- Changes being persisted after the page is reloaded:

[video.mov](https://github.com/user-attachments/assets/ffc6d4c3-eb1c-4b95-a448-8e5676a143ba)


