### PR TITLE
Fix deploy

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -10,6 +10,9 @@ jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
     steps:
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/checkout@v2
       - name: Install Vercel CLI
         run: npm install --global vercel@latest


### PR DESCRIPTION
### Summary

Deploy was failing since `pnpm` was not installed in the workflow. Added `pnpm/action-setup@v4`.

### Test Cases

- Verify that after pushing changes to main, the project deploys correctly to https://i-am-hired.vercel.app/.